### PR TITLE
Func point

### DIFF
--- a/cuda/Box.cu
+++ b/cuda/Box.cu
@@ -35,14 +35,21 @@ void Box::exteriorIntersect(Vec3<float> *d_origins,
     CudaErrchk( cudaMalloc(&simp_times, 2*N*sizeof(float)) );
     initArray<float><<<numBlocks, blockSize>>>(simp_times, 2*N, -5);
     CudaErrchkNoCode();
+    float *d_data;
+    CudaErrchk( cudaMalloc(&d_data, 3*sizeof(float)) );
+    CudaErrchk( cudaMemcpy(d_data, data, 3*sizeof(float), cudaMemcpyHostToDevice) );
     // These vectors are resized to match the size of the arrays above.
     int_times.resize(2*N);
     int_coords.resize(2*N);
     // The kernels are called to perform the intersection calculation.
-    intersectBox<<<numBlocks, blockSize>>>(d_origins,
+    /*intersectBox<<<numBlocks, blockSize>>>(d_origins,
                                            d_vel,
                                            X, Y, Z,
-                                           N, device_time, intersect);
+                                           N, device_time, intersect);*/
+    intersect<<<numBlocks, blockSize>>>(std::get<0>(funcPtrDict[type]),
+                                        d_origins, d_vel, d_data, N,
+                                        std::get<1>(funcPtrDict[type]),
+                                        device_time, intersect);
     //simplifyTimes<<<numBlocks, blockSize>>>(device_time, N, 6, 2, simp_times);
     simplifyTimePointPairs<<<numBlocks, blockSize>>>(device_time, 
                                                      intersect,
@@ -64,6 +71,7 @@ void Box::exteriorIntersect(Vec3<float> *d_origins,
     CudaErrchk( cudaFree(device_time) );
     CudaErrchk( cudaFree(intersect) );
     CudaErrchk( cudaFree(simp_times) );
+    CudaErrchk( cudaFree(d_data) );
 }
 
 void Box::interiorIntersect(Vec3<float> *d_origins,
@@ -112,14 +120,21 @@ void Box::interiorIntersect(Vec3<float> *d_origins,
     CudaErrchk( cudaMalloc(&simp_int, N*sizeof(Vec3<float>)) );
     initArray< Vec3<float> ><<<numBlocks, blockSize>>>(simp_int, N, Vec3<float>(FLT_MAX, FLT_MAX, FLT_MAX));
     CudaErrchkNoCode();
+    float *d_data;
+    CudaErrchk( cudaMalloc(&d_data, 3*sizeof(float)) );
+    CudaErrchk( cudaMemcpy(d_data, data, 3*sizeof(float), cudaMemcpyHostToDevice) );
     // These vectors are resized to match the size of the arrays above.
     int_times.resize(N);
     int_coords.resize(N);
     // The kernels are called to perform the intersection calculation.
-    intersectBox<<<numBlocks, blockSize>>>(d_origins,
+    /*intersectBox<<<numBlocks, blockSize>>>(d_origins,
                                            d_vel,
                                            X, Y, Z,
-                                           N, device_time, intersect);
+                                           N, device_time, intersect);*/
+    intersect<<<numBlocks, blockSize>>>(std::get<0>(funcPtrDict[type]),
+                                        d_origins, d_vel, d_data, N,
+                                        std::get<1>(funcPtrDict[type]),
+                                        device_time, intersect);
 #if defined(INTERIORTEST)
     Vec3<float> *ec = exit_coords.data();
     float *et = exit_times.data();
@@ -167,4 +182,5 @@ void Box::interiorIntersect(Vec3<float> *d_origins,
     CudaErrchk( cudaFree(intersect) );
     CudaErrchk( cudaFree(simp_times) );
     CudaErrchk( cudaFree(simp_int) );
+    CudaErrchk( cudaFree(d_data) );
 }

--- a/cuda/CudaDriver.cu
+++ b/cuda/CudaDriver.cu
@@ -359,9 +359,10 @@ void CudaDriver::findScatteringVels()
     /* Calls the elasticScatteringKernel function to update the neutron
      * velocities post-elastic scattering.
      */
-    elasticScatteringKernel<<<numBlocks, blockSize>>>(d_times,
-                                                      d_vel,
-                                                      d_randnums, N);
+    /*isotropicScatteringKernel<<<numBlocks, blockSize>>>(d_times,
+                                                        d_vel,
+                                                        d_randnums, N);*/
+    scatter<<<numBlocks, blockSize>>>(0, d_times, d_vel, d_randnums, N);
     CudaErrchkNoCode();
     /* Copies the new neutron velocities into the host-side neutron
      * velocity array.

--- a/cuda/IntersectKernels.cu
+++ b/cuda/IntersectKernels.cu
@@ -1,11 +1,10 @@
 #include "IntersectKernels.hpp"
 
-__device__ void intersectRectangle(float* ts, Vec3<float>* pts,
+__device__ void intersectRectangle(float &ts, Vec3<float> &pts,
                                    const Vec3<float> &orig, float zdiff,
                                    const Vec3<float> &vel,
                                    const float A, const float B,
-                                   const int key, const int groupSize, 
-                                   const int off1, int &off2)
+                                   const int key, int &off)
 {
     /* The system is temporarily shifted so that the plane potentially
      * being intersected lies along a coordinate plane (i.e. if the
@@ -20,7 +19,6 @@ __device__ void intersectRectangle(float* ts, Vec3<float>* pts,
      * The intersection point is calculated using basic kinematics.
      */
     Vec3<float> pt = orig + vel*t;
-    int index = blockIdx.x * blockDim.x + threadIdx.x;
     /* These nested if-statements convert the key into a pair of
      * values that are used to ensure the intersection point is
      * within the rectangle.
@@ -30,13 +28,13 @@ __device__ void intersectRectangle(float* ts, Vec3<float>* pts,
     // This if-statement ensures the intersection is within the rectangle.
     if (fabsf(pt[n1]) < (A/2) && fabsf(pt[n2]) < (B/2))
     {
-        if (off2 < 2)
+        if (off < 2)
         {
-            pts[2*index + off2] = pt;
-            // Increases off2 to prevent data overwrite.
-            off2++;
+            pts = pt;
+            // Increases off to prevent data overwrite.
+            off++;
         }
-        ts[off1 + index*groupSize] = t;
+        ts = t;
     }
     /* If the intersection coordinates do not fall within the rectangle,
      * a time of -1 is assigned to the function call's element in ts.
@@ -44,7 +42,7 @@ __device__ void intersectRectangle(float* ts, Vec3<float>* pts,
      */
     else
     {
-        ts[off1 + index*groupSize] = -1;
+        ts = -1;
     }
 }
 
@@ -64,7 +62,6 @@ __device__ void intersectCylinderSide(float *ts, Vec3<float> *pts,
     float b = 2*(orig[0]*vel[0] + orig[1]*vel[1]);
     float c = orig[0]*orig[0] + orig[1]*orig[1] - r*r; 
     float t0, t1;
-    int index = blockIdx.x * blockDim.x + threadIdx.x;
     /* If the solveQuadratic function returns false, there are no
      * valid intersection times. As a result, there is no
      * intersection with the Cylinder's side, and the corresponding
@@ -72,8 +69,8 @@ __device__ void intersectCylinderSide(float *ts, Vec3<float> *pts,
      */
     if (!solveQuadratic(a, b, c, t0, t1))
     {
-        ts[4*index + 2] = -1;
-        ts[4*index + 3] = -1;
+        ts[0] = -1;
+        ts[1] = -1;
     }
     /* In this case, there is a valid intersection with the Cylinder's 
      * side. However, since t0 < 0 and since t0 is guaranteed to be
@@ -87,71 +84,68 @@ __device__ void intersectCylinderSide(float *ts, Vec3<float> *pts,
          * second intersection is not possible in this case, this element
          * of ts is given a default value of -1.
          */
-        ts[4*index + 3] = -1;
+        ts[1] = -1;
         /* The neutron only intersects the side of the Cylinder 
          * if the absolute value of the Z-coordinate of the intersection
          * point is less than h/2.
          */
         if (fabsf(orig[2]+vel[2]*t1) < h/2)
         {
-            ts[4*index + 2] = t1;
+            ts[0] = t1;
             // See intersectRectangle
             if (offset < 2)
             {
-                pts[2*index + offset] = orig + (vel*t1);
+                pts[offset] = orig + (vel*t1);
                 offset++;
             }
         }
         else
         {
-            ts[4*index + 2] = -1;
+            ts[0] = -1;
         }
     }
     // In this case, there are two valid intersection times.
     else
     {
         // i is used to track the offset for ts
-        int i = 2;
+        int i = 0;
         if (fabsf(orig[2]+vel[2]*t0) < h/2)
         {
-            ts[4*index + i] = t0;
+            ts[i] = t0;
             i++;
             if (offset < 2)
             {
-                pts[2*index + offset] = orig + (vel*t0);
+                pts[offset] = orig + (vel*t0);
                 offset++;
             }
         }
         if (fabsf(orig[2]+vel[2]*t1) < h/2)
         {
-            ts[4*index + i] = t1;
+            ts[i] = t1;
             i++;
             if (offset < 2)
             {
-                pts[2*index + offset] = orig + (vel*t1);
+                pts[offset] = orig + (vel*t1);
                 offset++;
             }
         }
-        /* If i < 4, at least one time was not set in ts.
+        /* If i < 2, at least one time was not set in ts.
          * This if-statement will set the time of these unset
          * elements to -1.
          */
-        if (i < 4)
+        if (i < 2)
         {
-            for (int j = i; j < 4; j++)
+            for (int j = i; j < 2; j++)
             {
-                ts[4*index + j] = -1;
+                ts[j] = -1;
             }
         }
     }
     // Again used to prevent memory corruption
-    __syncthreads();
+    //__syncthreads();
 }
 
-__device__ void intersectCylinderTopBottom(//float *ts, float *pts,
-                                           float *ts, Vec3<float> *pts,
-                                           //float x, float y, float z,
-                                           //float vx, float vy, float vz,
+__device__ void intersectCylinderTopBottom(float *ts, Vec3<float> *pts,
                                            const Vec3<float> &orig,
                                            const Vec3<float> &vel,
                                            const float r, const float h,
@@ -161,7 +155,6 @@ __device__ void intersectCylinderTopBottom(//float *ts, float *pts,
     float r2 = r*r;
     float hh = h/2;
     Vec3<float> faceint;
-    int index = blockIdx.x * blockDim.x + threadIdx.x;
     /* Time is calculated by dividing the Z-distance the neutron has
      * to travel to reach the Z-coordinate of the top of the Cylinder
      * by the Z component of the neutron's velocity.
@@ -178,33 +171,33 @@ __device__ void intersectCylinderTopBottom(//float *ts, float *pts,
      */
     if (faceint[0]*faceint[0] + faceint[1]*faceint[1] <= r2)
     {
-        ts[4*index] = t;
+        ts[0] = t;
         if (offset < 2)
         {
-            pts[2*index + offset] = faceint;
+            pts[offset] = faceint;
             offset++;
         }
     }
     // Otherwise, the time is stored as -1.
     else
     {
-        ts[4*index] = -1;
+        ts[0] = -1;
     }
     // Repeat the above step for the bottom face of the Cylinder.
     t = (-hh-orig[2])/vel[2];
     faceint = orig + (vel * t);
     if (faceint[0]*faceint[0] + faceint[1]*faceint[1] <= r2)
     {
-        ts[4*index + 1] = t;
+        ts[1] = t;
         if (offset < 2)
         {
-            pts[2*index + offset] = faceint;
+            pts[offset] = faceint;
             offset++;
         }
     }
     else
     {
-        ts[4*index + 1] = -1;
+        ts[1] = -1;
     }
 }
 
@@ -215,15 +208,14 @@ __device__ void intersectCylinderTopBottom(//float *ts, float *pts,
  * Note that this algorithm is not the same as the one used
  * currently in McVine.
  */
-__device__ void intersectTriangle(float *ts, Vec3<float> *pts,
+__device__ void intersectTriangle(float &ts, Vec3<float> &pts,
                                   const Vec3<float> &orig,
                                   const Vec3<float> &vel,
                                   const Vec3<float> &a,
                                   const Vec3<float> &b,
                                   const Vec3<float> &c,
-                                  const int off1, int &off2)
+                                  int &off)
 {   
-    int index = blockIdx.x * blockDim.x + threadIdx.x;
     const float EPSILON = 1e-7;
     /* edge1 is the vector corresponding to the edge of the
      *     triangle between vertices a and b.
@@ -252,7 +244,7 @@ __device__ void intersectTriangle(float *ts, Vec3<float> *pts,
      */
     if (fabsf(denom) < EPSILON)
     {
-        ts[5*index + off1] = -1;
+        ts = -1;
         return;
     }
     frac = 1/denom;
@@ -271,7 +263,7 @@ __device__ void intersectTriangle(float *ts, Vec3<float> *pts,
      */
     if (u < 0 || u > 1)
     {
-        ts[5*index + off1] = -1;
+        ts = -1;
         return;
     }
     q = s * edge1;
@@ -283,7 +275,7 @@ __device__ void intersectTriangle(float *ts, Vec3<float> *pts,
      */
     if (v < 0 || u+v > 1)
     {
-        ts[5*index + off1] = -1;
+        ts = -1;
         return;
     }
     float t = frac * (edge2 | q);
@@ -295,211 +287,219 @@ __device__ void intersectTriangle(float *ts, Vec3<float> *pts,
     /* If the code gets to this point, there is a valid intersection,
      * and the intersection data is stored.
      */
-    ts[5*index + off1] = t;
-    if (off2 < 2)
+    ts = t;
+    if (off < 2)
     {
-        pts[2*index + off2] = orig + vel*t;
-        off2++;
+        pts = orig + vel*t;
+        off++;
     }
 }
 
-__global__ void intersectBox(Vec3<float>* origins,
-                             Vec3<float>* vel,
-                             const float X, const float Y, const float Z, 
-                             const int N, float* ts, Vec3<float>* pts)
+// Data is going to be broken down into groupings in intersect kernel.
+__device__ void intersectBox(Vec3<float>& origins,
+                             Vec3<float>& vel,
+                             const float *shapeData,
+                             float* ts, Vec3<float>* pts)
 {
-    int index = blockIdx.x * blockDim.x + threadIdx.x;
-    // This is done to prevent excess threads from interfering in the code.
-    if (index < N)
+    /* The offset variable is used to ensure only
+     * 2 intersection points are recorded.
+     */
+    int offset = 0;
+    /* If the neutron does not move in the Z-direction, there will
+     * never be an intersection with the top or bottom. So,
+     * the times for top and bottom intersection are set to -1.
+     * Otherwise, the intersectRectangle function is used to
+     * calculate any potential intersection times and points.
+     */
+    if (vel[2] != 0)
     {
-        /* The offset variable is used to ensure only
-         * 2 intersection points are recorded.
-         */
-        int offset = 0;
-        /* If the neutron does not move in the Z-direction, there will
-         * never be an intersection with the top or bottom. So,
-         * the times for top and bottom intersection are set to -1.
-         * Otherwise, the intersectRectangle function is used to
-         * calculate any potential intersection times and points.
-         */
-        if (vel[index][2] != 0)
-        {
-            intersectRectangle(ts, pts, origins[index], Z/2, vel[index], X, Y, 0, 6, 0, offset);
-            intersectRectangle(ts, pts, origins[index], -Z/2, vel[index], X, Y, 0, 6, 1, offset);
-        }
-        else
-        {
-            ts[index*6] = -1;
-            ts[index*6 + 1] = -1;
-        }
-        /* If the neutron does not move in the X-direction, there will
-         * never be an intersection with the sides parallel to the YZ plane.
-         * So, the times for these intersections are set to -1.
-         * Otherwise, the intersectRectangle function is used to
-         * calculate any potential intersection times and points.
-         */
-        if (vel[index][0] != 0)
-        {
-            intersectRectangle(ts, pts, origins[index], X/2, vel[index], Y, Z, 2, 6, 2, offset);
-            intersectRectangle(ts, pts, origins[index], -X/2, vel[index], Y, Z, 2, 6, 3, offset);
-        }
-        else
-        {
-            ts[index*6 + 2] = -1;
-            ts[index*6 + 3] = -1;
-        }
-        /* If the neutron does not move in the Y-direction, there will
-         * never be an intersection with the sides parallel to the XZ plane.
-         * So, the times for these intersections are set to -1.
-         * Otherwise, the intersectRectangle function is used to
-         * calculate any potential intersection times and points.
-         */
-        if (vel[index][1] != 0)
-        {
-            intersectRectangle(ts, pts, origins[index], Y/2, vel[index], Z, X, 1, 6, 4, offset);
-            intersectRectangle(ts, pts, origins[index], -Y/2, vel[index], Z, X, 1, 6, 5, offset);
-        }
-        else
-        {
-            ts[index*6 + 4] = -1;
-            ts[index*6 + 5] = -1;
-        }
+        intersectRectangle(ts[0], pts[offset], origins, shapeData[2]/2, vel, shapeData[0], shapeData[1], 0, offset);
+        intersectRectangle(ts[1], pts[offset], origins, -shapeData[2]/2, vel, shapeData[0], shapeData[1], 0, offset);
+    }
+    else
+    {
+        ts[0] = -1;
+        ts[1] = -1;
+    }
+    /* If the neutron does not move in the X-direction, there will
+     * never be an intersection with the sides parallel to the YZ plane.
+     * So, the times for these intersections are set to -1.
+     * Otherwise, the intersectRectangle function is used to
+     * calculate any potential intersection times and points.
+     */
+    if (vel[0] != 0 && offset < 2)
+    {
+        intersectRectangle(ts[2], pts[offset], origins, shapeData[0]/2, vel, shapeData[1], shapeData[2], 2, offset);
+        intersectRectangle(ts[3], pts[offset], origins, -shapeData[0]/2, vel, shapeData[1], shapeData[2], 2, offset);
+    }
+    else
+    {
+        ts[2] = -1;
+        ts[3] = -1;
+    }
+    /* If the neutron does not move in the Y-direction, there will
+     * never be an intersection with the sides parallel to the XZ plane.
+     * So, the times for these intersections are set to -1.
+     * Otherwise, the intersectRectangle function is used to
+     * calculate any potential intersection times and points.
+     */
+    if (vel[1] != 0 && offset < 2)
+    {
+        intersectRectangle(ts[4], pts[offset], origins, shapeData[1]/2, vel, shapeData[2], shapeData[0], 1, offset);
+        intersectRectangle(ts[5], pts[offset], origins, -shapeData[1]/2, vel, shapeData[2], shapeData[0], 1, offset);
+    }
+    else
+    {
+        ts[4] = -1;
+        ts[5] = -1;
     }
 }
 
-__global__ void intersectCylinder(Vec3<float> *origins, Vec3<float> *vel,
-                                  const float r, const float h,
-                                  const int N, float *ts, Vec3<float> *pts)
+__device__ void intersectCylinder(Vec3<float> &origins, Vec3<float> &vel,
+                                  const float *shapeData,
+                                  float *ts, Vec3<float> *pts)
 {
-    int index = blockIdx.x * blockDim.x + threadIdx.x;
-    // This is done to prevent excess threads from interfering in the code.
-    if (index < N)
-    {
-        /* The offset variable is used to ensure only
-         * 2 intersection points are recorded.
-         */
-        int offset = 0;
-        /* The actual intersection calculations are carried out
-         * by these two helper functions.
-         */
-        intersectCylinderTopBottom(ts, pts, origins[index], vel[index], r, h, offset);
-        intersectCylinderSide(ts, pts, origins[index], vel[index], r, h, offset);
-    }
+    /* The offset variable is used to ensure only
+     * 2 intersection points are recorded.
+     */
+    int offset = 0;
+    /* The actual intersection calculations are carried out
+     * by these two helper functions.
+     */
+    intersectCylinderTopBottom(&(ts[0]), pts, origins, vel, shapeData[0], shapeData[1], offset);
+    intersectCylinderSide(&(ts[2]), pts, origins, vel, shapeData[0], shapeData[1], offset);
 }
 
-__global__ void intersectPyramid(Vec3<float> *origins, Vec3<float> *vel,
-                                 const float X, const float Y, const float H,
-                                 const int N, float *ts, Vec3<float> *pts)
+__device__ void intersectPyramid(Vec3<float> &origins, Vec3<float> &vel,
+                                 const float *shapeData,
+                                 float *ts, Vec3<float> *pts)
 {
-    int index = blockIdx.x * blockDim.x + threadIdx.x;
-    // This is done to prevent excess threads from interfering in the code.
-    if (index < N)
+    /* The offset variable is used to ensure only
+     * 2 intersection points are recorded.
+     */
+    int offset = 0;
+    /* If the neutron doesn't move in the Z-direction, it will
+     * never intersect the Pyramid's base. If it might intersect,
+     * the intersectRectangle function is used to determine any
+     * intersection point.
+     */
+    if (vel[2] != 0)
     {
-        /* The offset variable is used to ensure only
-         * 2 intersection points are recorded.
-         */
-        int offset = 0;
-        /* If the neutron doesn't move in the Z-direction, it will
-         * never intersect the Pyramid's base. If it might intersect,
-         * the intersectRectangle function is used to determine any
-         * intersection point.
-         */
-        if (vel[index][2] != 0)
-        {
-            intersectRectangle(ts, pts, origins[index], -H, vel[index], X, Y, 0, 5, 0, offset);
-        }
-        /* These calls to intersectTriangle determine if there are
-         * any intersections between the neutron and the triangular
-         * faces of the Pyramid.
-         */
-        intersectTriangle(ts, pts,
-                          origins[index],
-                          vel[index],
-                          Vec3<float>(0, 0, 0),
-                          Vec3<float>(X/2, Y/2, -H),
-                          Vec3<float>(X/2, -Y/2, -H),
-                          1, offset);
-        intersectTriangle(ts, pts,
-                          origins[index],
-                          vel[index],
-                          Vec3<float>(0, 0, 0),
-                          Vec3<float>(X/2, -Y/2, -H),
-                          Vec3<float>(-X/2, -Y/2, -H),
-                          2, offset);
-        intersectTriangle(ts, pts,
-                          origins[index],
-                          vel[index],
-                          Vec3<float>(0, 0, 0),
-                          Vec3<float>(-X/2, -Y/2, -H),
-                          Vec3<float>(-X/2, Y/2, -H),
-                          3, offset);
-        intersectTriangle(ts, pts,
-                          origins[index],
-                          vel[index],
-                          Vec3<float>(0, 0, 0),
-                          Vec3<float>(-X/2, Y/2, -H),
-                          Vec3<float>(X/2, Y/2, -H),
-                          4, offset);
-        __syncthreads();
+        intersectRectangle(ts[0], pts[offset], origins, -shapeData[2], vel, shapeData[0], shapeData[1], 0, offset);
     }
+    /* These calls to intersectTriangle determine if there are
+     * any intersections between the neutron and the triangular
+     * faces of the Pyramid.
+     */
+    intersectTriangle(ts[1], pts[offset],
+                      origins,
+                      vel,
+                      Vec3<float>(0, 0, 0),
+                      Vec3<float>(shapeData[0]/2, shapeData[1]/2, -shapeData[2]),
+                      Vec3<float>(shapeData[0]/2, -shapeData[1]/2, -shapeData[2]),
+                      offset);
+    if (offset >= 2)
+    {
+        ts[2] = -1; ts[3] = -1; ts[4] = -1;
+        return;
+    }
+    intersectTriangle(ts[2], pts[offset],
+                      origins,
+                      vel,
+                      Vec3<float>(0, 0, 0),
+                      Vec3<float>(shapeData[0]/2, -shapeData[1]/2, -shapeData[2]),
+                      Vec3<float>(-shapeData[0]/2, -shapeData[1]/2, -shapeData[2]),
+                      offset);
+    if (offset >= 2)
+    {
+        ts[3] = -1; ts[4] = -1;
+        return;
+    }
+    intersectTriangle(ts[3], pts[offset],
+                      origins,
+                      vel,
+                      Vec3<float>(0, 0, 0),
+                      Vec3<float>(-shapeData[0]/2, -shapeData[1]/2, -shapeData[2]),
+                      Vec3<float>(-shapeData[0]/2, shapeData[1]/2, -shapeData[2]),
+                      offset);
+    if (offset >= 2)
+    {
+        ts[4] = -1;
+        return;
+    }
+    intersectTriangle(ts[4], pts[offset],
+                      origins,
+                      vel,
+                      Vec3<float>(0, 0, 0),
+                      Vec3<float>(-shapeData[0]/2, shapeData[1]/2, -shapeData[2]),
+                      Vec3<float>(shapeData[0]/2, shapeData[1]/2, -shapeData[2]),
+                      offset);
+    //__syncthreads();
 }
 
-__global__ void intersectSphere(Vec3<float> *origins, Vec3<float> *vel,
-                                const float radius,
-                                const int N, float *ts, Vec3<float> *pts)
+__device__ void intersectSphere(Vec3<float> &origins, Vec3<float> &vel,
+                                const float *shapeData,
+                                float *ts, Vec3<float> *pts)
 {
-    int index = blockIdx.x * blockDim.x + threadIdx.x;
-    // This is done to prevent excess threads from interfering in the code.
-    if (index < N)
+    /* Calculates the a, b, and c parameters needed for the
+     * quadratic formula. These parameters are defined by the
+     * equation that is developed by plugging the components
+     * of the ray equation for a neutron
+     * (<x,y,z> = <x0,y0,z0>+t*<vx,vy,vz>) into the equation of
+     * a Sphere.
+     */
+    float a = (vel | vel);
+    float b = 2*(origins | vel);
+    float c = (origins | origins);
+    c -= shapeData[0]*shapeData[0];
+    /* The solveQuadratic function is used to calculate the
+     * two potential intersection times. If the function
+     * returns false, the neutron does not intersect, and the
+     * corresponding values in ts are set to -1.
+     */
+    float t0, t1;
+    if (!solveQuadratic(a, b, c, t0, t1))
     {
-        /* Calculates the a, b, and c parameters needed for the
-         * quadratic formula. These parameters are defined by the
-         * equation that is developed by plugging the components
-         * of the ray equation for a neutron
-         * (<x,y,z> = <x0,y0,z0>+t*<vx,vy,vz>) into the equation of
-         * a Sphere.
-         */
-        float a = (vel[index] | vel[index]);
-        float b = 2*(origins[index] | vel[index]);
-        float c = (origins[index] | origins[index]);
-        c -= radius*radius;
-        /* The solveQuadratic function is used to calculate the
-         * two potential intersection times. If the function
-         * returns false, the neutron does not intersect, and the
-         * corresponding values in ts are set to -1.
-         */
-        float t0, t1;
-        if (!solveQuadratic(a, b, c, t0, t1))
+        ts[0] = -1;
+        ts[1] = -1;
+        return;
+    }
+    /* If solveQuadratic returns true, the times are stored in 
+     * ts, and the intersection points are calculated and stored
+     * in pts.
+     */
+    else
+    {
+        if (t0 < 0)
         {
-            ts[2*index] = -1;
-            ts[2*index + 1] = -1;
-            return;
+            ts[0] = -1;
         }
-        /* If solveQuadratic returns true, the times are stored in 
-         * ts, and the intersection points are calculated and stored
-         * in pts.
-         */
         else
         {
-            if (t0 < 0)
-            {
-                ts[2*index] = -1;
-            }
-            else
-            {
-                ts[2*index] = t0;
-                pts[2*index] = origins[index] + (vel[index] * t0);
-            }
-            if (t1 < 0)
-            {
-                ts[2*index+1] = -1;
-            }
-            else
-            {
-                ts[2*index + 1] = t1;
-                pts[2*index + 1] = origins[index] + (vel[index] * t1);
-            }
+            ts[0] = t0;
+            pts[0] = origins + (vel * t0);
         }
-        __syncthreads();
+        if (t1 < 0)
+        {
+            ts[1] = -1;
+        }
+        else
+        {
+            ts[1] = t1;
+            pts[1] = origins + (vel * t1);
+        }
+    }
+    //__syncthreads();
+}
+
+__global__ void intersect(intersectStart_t intPtr, Vec3<float> *origins,
+                          Vec3<float> *vel, const float *shapeData,
+                          const int N, const int groupSize,
+                          float *ts, Vec3<float> *pts)
+{
+    int index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index < N)
+    {
+        (*intPtr)(origins[index], vel[index], shapeData, &(ts[groupSize*index]), &(pts[2*index]));
     }
 }

--- a/cuda/IntersectKernels.cu
+++ b/cuda/IntersectKernels.cu
@@ -207,7 +207,7 @@ __device__ void intersectCylinderTopBottom(float *ts, Vec3<float> *pts,
  * Note that this algorithm is not the same as the one used
  * currently in McVine.
  */
-__device__ void intersectTriangle(float &ts, Vec3<float> &pts,
+__device__ void intersectTriangle(float &ts, Vec3<float> *pts,
                                   const Vec3<float> &orig,
                                   const Vec3<float> &vel,
                                   const Vec3<float> &a,
@@ -289,7 +289,7 @@ __device__ void intersectTriangle(float &ts, Vec3<float> &pts,
     ts = t;
     if (off < 2)
     {
-        pts = orig + vel*t;
+        pts[off] = orig + vel*t;
         off++;
     }
 }
@@ -386,47 +386,36 @@ __device__ void intersectPyramid(Vec3<float> &origins, Vec3<float> &vel,
     {
         intersectRectangle(ts[0], pts[offset], origins, -shapeData[2], vel, shapeData[0], shapeData[1], 0, offset);
     }
+    else
+    {
+        ts[0] = -1;
+    }
     /* These calls to intersectTriangle determine if there are
      * any intersections between the neutron and the triangular
      * faces of the Pyramid.
      */
-    intersectTriangle(ts[1], pts[offset],
+    intersectTriangle(ts[1], pts,
                       origins,
                       vel,
                       Vec3<float>(0, 0, 0),
                       Vec3<float>(shapeData[0]/2, shapeData[1]/2, -shapeData[2]),
                       Vec3<float>(shapeData[0]/2, -shapeData[1]/2, -shapeData[2]),
                       offset);
-    if (offset >= 2)
-    {
-        ts[2] = -1; ts[3] = -1; ts[4] = -1;
-        return;
-    }
-    intersectTriangle(ts[2], pts[offset],
+    intersectTriangle(ts[2], pts,
                       origins,
                       vel,
                       Vec3<float>(0, 0, 0),
                       Vec3<float>(shapeData[0]/2, -shapeData[1]/2, -shapeData[2]),
                       Vec3<float>(-shapeData[0]/2, -shapeData[1]/2, -shapeData[2]),
                       offset);
-    if (offset >= 2)
-    {
-        ts[3] = -1; ts[4] = -1;
-        return;
-    }
-    intersectTriangle(ts[3], pts[offset],
+    intersectTriangle(ts[3], pts,
                       origins,
                       vel,
                       Vec3<float>(0, 0, 0),
                       Vec3<float>(-shapeData[0]/2, -shapeData[1]/2, -shapeData[2]),
                       Vec3<float>(-shapeData[0]/2, shapeData[1]/2, -shapeData[2]),
                       offset);
-    if (offset >= 2)
-    {
-        ts[4] = -1;
-        return;
-    }
-    intersectTriangle(ts[4], pts[offset],
+    intersectTriangle(ts[4], pts,
                       origins,
                       vel,
                       Vec3<float>(0, 0, 0),

--- a/cuda/Pyramid.cu
+++ b/cuda/Pyramid.cu
@@ -22,9 +22,9 @@ void Pyramid::exteriorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
      * This array will store the intersection coordinates calculated
      * by the intersectPyramid kernel.
      */
-    Vec3<float> *intersect;
-    CudaErrchk( cudaMalloc(&intersect, 2*N*sizeof(Vec3<float>)) );
-    initArray< Vec3<float> ><<<numBlocks, blockSize>>>(intersect, 2*N, Vec3<float>(FLT_MAX, FLT_MAX, FLT_MAX));
+    Vec3<float> *d_intersect;
+    CudaErrchk( cudaMalloc(&d_intersect, 2*N*sizeof(Vec3<float>)) );
+    initArray< Vec3<float> ><<<numBlocks, blockSize>>>(d_intersect, 2*N, Vec3<float>(FLT_MAX, FLT_MAX, FLT_MAX));
     CudaErrchkNoCode();
     /* The device float array "simp_times" is allocated on device, and
      * its elements' values are set to -5.
@@ -44,16 +44,15 @@ void Pyramid::exteriorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
     /*intersectPyramid<<<numBlocks, blockSize>>>(d_origins, d_vel,
                                                edgeX, edgeY, height,
                                                N, device_time, intersect);*/
-    intersect<<<numBlocks, blockSize>>>(std::get<0>(funcPtrDict[type]),
+    intersect<<<numBlocks, blockSize>>>(interKeyDict[type],
                                         d_origins, d_vel, d_data, N,
-                                        std::get<1>(funcPtrDict[type]),
-                                        device_time, intersect);
+                                        device_time, d_intersect);
     simplifyTimePointPairs<<<numBlocks, blockSize>>>(device_time,
-                                                     intersect,
+                                                     d_intersect,
                                                      N, 5, 2, 2,
                                                      simp_times,
-                                                     intersect);
-    forceIntersectionOrder<<<numBlocks, blockSize>>>(simp_times, intersect, N);
+                                                     d_intersect);
+    forceIntersectionOrder<<<numBlocks, blockSize>>>(simp_times, d_intersect, N);
     CudaErrchkNoCode();
     /* The data from simp_times and intersect is copied into
      * int_times and int_coords respectively.
@@ -61,12 +60,12 @@ void Pyramid::exteriorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
     float *it = int_times.data();
     Vec3<float> *ic = int_coords.data();
     CudaErrchk( cudaMemcpy(it, simp_times, 2*N*sizeof(float), cudaMemcpyDeviceToHost) );
-    CudaErrchk( cudaMemcpy(ic, intersect, 2*N*sizeof(Vec3<float>), cudaMemcpyDeviceToHost) );
+    CudaErrchk( cudaMemcpy(ic, d_intersect, 2*N*sizeof(Vec3<float>), cudaMemcpyDeviceToHost) );
     /* The device memory allocated at the beginning of the function
      * is freed.
      */
     CudaErrchk( cudaFree(device_time) );
-    CudaErrchk( cudaFree(intersect) );
+    CudaErrchk( cudaFree(d_intersect) );
     CudaErrchk( cudaFree(simp_times) );
     CudaErrchk( cudaFree(d_data) );
 }
@@ -90,9 +89,9 @@ void Pyramid::interiorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
      * This array will store the intersection coordinates calculated
      * by the intersectPyramid kernel.
      */
-    Vec3<float> *intersect;
-    CudaErrchk( cudaMalloc(&intersect, 2*N*sizeof(Vec3<float>)) );
-    initArray< Vec3<float> ><<<numBlocks, blockSize>>>(intersect, 2*N, Vec3<float>(FLT_MAX, FLT_MAX, FLT_MAX));
+    Vec3<float> *d_intersect;
+    CudaErrchk( cudaMalloc(&d_intersect, 2*N*sizeof(Vec3<float>)) );
+    initArray< Vec3<float> ><<<numBlocks, blockSize>>>(d_intersect, 2*N, Vec3<float>(FLT_MAX, FLT_MAX, FLT_MAX));
     CudaErrchkNoCode();
     /* The device float array "simp_times" is allocated on device, and
      * its elements' values are set to -5.
@@ -120,12 +119,11 @@ void Pyramid::interiorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
     /*intersectPyramid<<<numBlocks, blockSize>>>(d_origins, d_vel,
                                                edgeX, edgeY, height,
                                                N, device_time, intersect);*/
-    intersect<<<numBlocks, blockSize>>>(std::get<0>(funcPtrDict[type]),
+    intersect<<<numBlocks, blockSize>>>(interKeyDict[type],
                                         d_origins, d_vel, d_data, N,
-                                        std::get<1>(funcPtrDict[type]),
-                                        device_time, intersect);
+                                        device_time, d_intersect);
     simplifyTimePointPairs<<<numBlocks, blockSize>>>(device_time,
-                                                     intersect,
+                                                     d_intersect,
                                                      N, 5, 2, 1,
                                                      simp_times,
                                                      simp_int);
@@ -141,7 +139,7 @@ void Pyramid::interiorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
      * is freed.
      */
     CudaErrchk( cudaFree(device_time) );
-    CudaErrchk( cudaFree(intersect) );
+    CudaErrchk( cudaFree(d_intersect) );
     CudaErrchk( cudaFree(simp_times) );
     CudaErrchk( cudaFree(simp_int) );
     CudaErrchk( cudaFree(d_data) );

--- a/cuda/Sphere.cu
+++ b/cuda/Sphere.cu
@@ -27,9 +27,9 @@ void Sphere::exteriorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
      * This array will store the intersection coordinates calculated
      * by the intersectSphere kernel.
      */
-    Vec3<float> *intersect;
-    CudaErrchk( cudaMalloc(&intersect, 2*N*sizeof(Vec3<float>)) );
-    initArray< Vec3<float> ><<<numBlocks, blockSize>>>(intersect, 2*N, Vec3<float>(FLT_MAX, FLT_MAX, FLT_MAX));
+    Vec3<float> *d_intersect;
+    CudaErrchk( cudaMalloc(&d_intersect, 2*N*sizeof(Vec3<float>)) );
+    initArray< Vec3<float> ><<<numBlocks, blockSize>>>(d_intersect, 2*N, Vec3<float>(FLT_MAX, FLT_MAX, FLT_MAX));
     CudaErrchkNoCode();
     float *d_data;
     CudaErrchk( cudaMalloc(&d_data, sizeof(float)) );
@@ -40,11 +40,10 @@ void Sphere::exteriorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
     /*intersectSphere<<<numBlocks, blockSize>>>(d_origins, d_vel,
                                               radius,
                                               N, device_time, intersect);*/
-    intersect<<<numBlocks, blockSize>>>(std::get<0>(funcPtrDict[type]),
+    intersect<<<numBlocks, blockSize>>>(interKeyDict[type],
                                         d_origins, d_vel, d_data, N,
-                                        std::get<1>(funcPtrDict[type]),
-                                        device_time, intersect);
-    forceIntersectionOrder<<<numBlocks, blockSize>>>(device_time, intersect, N);
+                                        device_time, d_intersect);
+    forceIntersectionOrder<<<numBlocks, blockSize>>>(device_time, d_intersect, N);
     CudaErrchkNoCode();
     /* The data from device_time and intersect is copied into
      * int_times and int_coords respectively.
@@ -52,12 +51,12 @@ void Sphere::exteriorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
     float *it = int_times.data();
     Vec3<float> *ic = int_coords.data();
     CudaErrchk( cudaMemcpy(it, device_time, 2*N*sizeof(float), cudaMemcpyDeviceToHost) );
-    CudaErrchk( cudaMemcpy(ic, intersect, 2*N*sizeof(Vec3<float>), cudaMemcpyDeviceToHost) );
+    CudaErrchk( cudaMemcpy(ic, d_intersect, 2*N*sizeof(Vec3<float>), cudaMemcpyDeviceToHost) );
     /* The device memory allocated at the beginning of the function
      * is freed.
      */
     CudaErrchk( cudaFree(device_time) );
-    CudaErrchk( cudaFree(intersect) );
+    CudaErrchk( cudaFree(d_intersect) );
     CudaErrchk( cudaFree(d_data) );
 }
 
@@ -80,9 +79,9 @@ void Sphere::interiorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
      * This array will store the intersection coordinates calculated
      * by the intersectSphere kernel.
      */
-    Vec3<float> *intersect;
-    CudaErrchk( cudaMalloc(&intersect, 2*N*sizeof(Vec3<float>)) );
-    initArray< Vec3<float> ><<<numBlocks, blockSize>>>(intersect, 2*N, Vec3<float>(FLT_MAX, FLT_MAX, FLT_MAX));
+    Vec3<float> *d_intersect;
+    CudaErrchk( cudaMalloc(&d_intersect, 2*N*sizeof(Vec3<float>)) );
+    initArray< Vec3<float> ><<<numBlocks, blockSize>>>(d_intersect, 2*N, Vec3<float>(FLT_MAX, FLT_MAX, FLT_MAX));
     CudaErrchkNoCode();
     /* The float array "simp_times" is allocated on the deivce, and
      * its elements' values are set to -5.
@@ -109,12 +108,11 @@ void Sphere::interiorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
     /*intersectSphere<<<numBlocks, blockSize>>>(d_origins, d_vel,
                                               radius,
                                               N, device_time, intersect);*/
-    intersect<<<numBlocks, blockSize>>>(std::get<0>(funcPtrDict[type]),
+    intersect<<<numBlocks, blockSize>>>(interKeyDict[type],
                                         d_origins, d_vel, d_data, N,
-                                        std::get<1>(funcPtrDict[type]),
-                                        device_time, intersect);
+                                        device_time, d_intersect);
     simplifyTimePointPairs<<<numBlocks, blockSize>>>(device_time,
-                                                     intersect,
+                                                     d_intersect,
                                                      N, 2, 2, 1,
                                                      simp_times,
                                                      simp_int);
@@ -130,7 +128,7 @@ void Sphere::interiorIntersect(Vec3<float> *d_origins, Vec3<float> *d_vel,
      * is freed.
      */
     CudaErrchk( cudaFree(device_time) );
-    CudaErrchk( cudaFree(intersect) );
+    CudaErrchk( cudaFree(d_intersect) );
     CudaErrchk( cudaFree(simp_times) );
     CudaErrchk( cudaFree(simp_int) );
     CudaErrchk( cudaFree(d_data) );

--- a/include/AbstractShape.hpp
+++ b/include/AbstractShape.hpp
@@ -15,9 +15,7 @@
 #include "Ray.hpp"
 #include "SystemVars.hpp"
 
-typedef std::pair<intersectStart_t, int> devicePair;
-
-extern std::unordered_map<std::string, devicePair> funcPtrDict;
+extern std::unordered_map<std::string, int> interKeyDict;
 
 /* Abstract Shape is the parent interface for the primitive
  * solids defined in McVine.
@@ -26,29 +24,7 @@ extern std::unordered_map<std::string, devicePair> funcPtrDict;
  */
 struct AbstractShape
 {
-    AbstractShape() 
-    { 
-        type = "Shape"; 
-        if (funcPtrDict.empty())
-        {
-            funcPtrDict.insert(
-                std::make_pair<std::string, devicePair>("Box", 
-                std::make_pair<intersectStart_t, int>(NULL, 6)));
-            funcPtrDict.insert(
-                std::make_pair<std::string, devicePair>("Cylinder", 
-                std::make_pair<intersectStart_t, int>(NULL, 4)));
-            funcPtrDict.insert(
-                std::make_pair<std::string, devicePair>("Pyramid", 
-                std::make_pair<intersectStart_t, int>(NULL, 5)));
-            funcPtrDict.insert(
-                std::make_pair<std::string, devicePair>("Sphere", 
-                std::make_pair<intersectStart_t, int>(NULL, 2)));
-            CudaErrchk( cudaMemcpyFromSymbol(&(std::get<0>(funcPtrDict["Box"])), boxInt, sizeof(intersectStart_t)) );
-            CudaErrchk( cudaMemcpyFromSymbol(&(std::get<0>(funcPtrDict["Cylinder"])), cylInt, sizeof(intersectStart_t)) );
-            CudaErrchk( cudaMemcpyFromSymbol(&(std::get<0>(funcPtrDict["Pyramid"])), pyrInt, sizeof(intersectStart_t)) );
-            CudaErrchk( cudaMemcpyFromSymbol(&(std::get<0>(funcPtrDict["Sphere"])), sphInt, sizeof(intersectStart_t)) );
-        }
-    }
+    AbstractShape(); 
 
     virtual ~AbstractShape() { ; }
 

--- a/include/Box.hpp
+++ b/include/Box.hpp
@@ -10,19 +10,25 @@
 struct Box : public AbstractShape
 {
     // Default Constructor
-    Box() { type = "Box"; }
-
-    /* "Explicit" Constructor.
-     * This function takes three doubles and sets the side lengths
-     * with them.
-     */
-    Box(const double a, const double b, const double c)
-    {
-        X=a; Y=b; Z=c;
-        type = "Box";
+    Box() 
+    { 
+        type = "Box"; 
+        data = new float[3];
+        data[0] = 0; data[1] = 0; data[2] = 0;
     }
 
-    ~Box() { ; }
+    /* "Explicit" Constructor.
+     * This function takes three floats and sets the side lengths
+     * with them.
+     */
+    Box(const float a, const float b, const float c)
+    {
+        type = "Box";
+        data = new float[3];
+        data[0] = a; data[1] = b; data[2] = c;
+    }
+
+    ~Box() { delete [] data; }
     
     /* The function that handles the calculation of the intersection
      * points and times between the Box object and the neutrons represented
@@ -41,9 +47,6 @@ struct Box : public AbstractShape
                                    const int N, const int blockSize, const int numBlocks,
                                    std::vector<float> &int_times,
                                    std::vector< Vec3<float> > &int_coords) override;
-
-    // These members store the Box's side lengths in the X, Y, and Z directions.
-    double X, Y, Z;
 };
 
 #endif

--- a/include/Cylinder.hpp
+++ b/include/Cylinder.hpp
@@ -12,20 +12,26 @@
 struct Cylinder : public AbstractShape
 {
     // Default Constructor
-    Cylinder() { type = "Cylinder"; }
+    Cylinder() 
+    { 
+        type = "Cylinder"; 
+        data = new float[2];
+        data[0] = 0; data[1] = 0;
+    }
     
     /* "Explicit" Constructor
-     * This function takes two doubles and uses them to set
+     * This function takes two floats and uses them to set
      * the Cylinder's radius and height.
      */
-    Cylinder(const double kRadius, const double kHeight)
+    Cylinder(const float kRadius, const float kHeight)
     {
-        radius = kRadius;
-        height = kHeight;
         type = "Cylinder";
+        data = new float[2];
+        data[0] = kRadius;
+        data[1] = kHeight;
     }
 
-    ~Cylinder() { ; }
+    ~Cylinder() { delete [] data; }
 
     /* The function that handles the calculation of the intersection
      * points and times between the Cylinder object and the neutrons
@@ -46,9 +52,6 @@ struct Cylinder : public AbstractShape
                                    const int N, const int blockSize, const int numBlocks,
                                    std::vector<float> &int_times, 
                                    std::vector< Vec3<float> > &int_coords) override;
-
-    // These members store the Cylinder's radius and height.
-    double radius, height;
 };
 
 #endif

--- a/include/IntersectKernels.hpp
+++ b/include/IntersectKernels.hpp
@@ -3,6 +3,9 @@
 
 #include "UtilKernels.hpp"
 
+typedef void (*intersectStart_t)(Vec3<float>&, Vec3<float>&, const float*,
+                                 float*, Vec3<float>*);
+
 /* This function calculates the intersection time and point between
  * a neutron (represented by x, y, z, va, vb, and vc) and a
  * rectangle (represented by A, B, and zdiff). The remaining
@@ -11,12 +14,11 @@
  * arrays.
  * This function can be called on device only.
  */
-__device__ void intersectRectangle(float* ts, Vec3<float>* pts,
+__device__ void intersectRectangle(float &ts, Vec3<float> &pts,
                                    const Vec3<float> &orig, float zdiff,
                                    const Vec3<float> &vel,
                                    const float A, const float B,
-                                   const int key, const int groupSize,
-                                   const int off1, int &off2);
+                                   const int key, int &off);
 
 /* This function calculates the intersection time and coordinates between
  * a neutron (represented by x, y, z, vx, vy, and vz) and the rounded
@@ -51,13 +53,13 @@ __device__ void intersectCylinderTopBottom(float *ts, Vec3<float> *pts,
  * in the correct spot in the ts and pts arrays.
  * This function can be called on device only.
  */
-__device__ void intersectTriangle(float *ts, Vec3<float> *pts,
+__device__ void intersectTriangle(float &ts, Vec3<float> &pts,
                                   const Vec3<float> &orig,
                                   const Vec3<float> &vel,
                                   const Vec3<float> &a,
                                   const Vec3<float> &b,
                                   const Vec3<float> &c,
-                                  const int off1, int &off2);
+                                  int &off);
 
 /* This function controlls the calculation of the intersections between
  * a collection of neutrons (represented by rx, ry, rz, vx, vy, and vz)
@@ -66,10 +68,10 @@ __device__ void intersectTriangle(float *ts, Vec3<float> *pts,
  * and coordinates are stored in the ts and pts arrays respectively.
  * This function can be called from host.
  */
-__global__ void intersectBox(Vec3<float>* origins,
-                             Vec3<float>* vel,
-                             const float X, const float Y, const float Z,
-                             const int N, float* ts, Vec3<float>* pts);
+__device__ void intersectBox(Vec3<float>& origins,
+                             Vec3<float>& vel,
+                             const float *shapeData,
+                             float* ts, Vec3<float>* pts);
 
 /* This function controlls the calculation of the intersections between
  * a collection of neutrons (represented by rx, ry, rz, vx, vy, and vz)
@@ -78,9 +80,9 @@ __global__ void intersectBox(Vec3<float>* origins,
  * and coordinates are stored in the ts and pts arrays respectively.
  * This function can be called from host.
  */
-__global__ void intersectCylinder(Vec3<float> *origins, Vec3<float> *vel,
-                                  const float r, const float h,
-                                  const int N, float *ts, Vec3<float> *pts);
+__device__ void intersectCylinder(Vec3<float> &origins, Vec3<float> &vel,
+                                  const float *shapeData,
+                                  float *ts, Vec3<float> *pts);
 
 /* This function controlls the calculation of the intersections between
  * a collection of neutrons (represented by rx, ry, rz, vx, vy, and vz)
@@ -89,9 +91,9 @@ __global__ void intersectCylinder(Vec3<float> *origins, Vec3<float> *vel,
  * and coordinates are stored in the ts and pts arrays respectively.
  * This function can be called from host.
  */
-__global__ void intersectPyramid(Vec3<float> *origins, Vec3<float> *vel,
-                                 const float X, const float Y, const float H,
-                                 const int N, float *ts, Vec3<float> *pts);
+__device__ void intersectPyramid(Vec3<float> &origins, Vec3<float> &vel,
+                                 const float *shapeData,
+                                 float *ts, Vec3<float> *pts);
 
 /* This function controlls the calculation of the intersections between
  * a collection of neutrons (represented by rx, ry, rz, vx, vy, and vz)
@@ -100,8 +102,18 @@ __global__ void intersectPyramid(Vec3<float> *origins, Vec3<float> *vel,
  * and coordinates are stored in the ts and pts arrays respectively.
  * This function can be called from host.
  */
-__global__ void intersectSphere(Vec3<float> *origins, Vec3<float> *vel,
-                                const float radius,
-                                const int N, float *ts, Vec3<float> *pts);
+__device__ void intersectSphere(Vec3<float> &origins, Vec3<float> &vel,
+                                const float *shapeData,
+                                float *ts, Vec3<float> *pts);
+
+__device__ intersectStart_t boxInt = intersectBox;
+__device__ intersectStart_t cylInt = intersectCylinder;
+__device__ intersectStart_t pyrInt = intersectPyramid;
+__device__ intersectStart_t sphInt = intersectSphere;
+
+__global__ void intersect(intersectStart_t intPtr, Vec3<float> *origins, 
+                          Vec3<float> *vel, const float *shapeData, 
+                          const int N, const int groupSize,
+                          float *ts, Vec3<float> *pts);
 
 #endif

--- a/include/IntersectKernels.hpp
+++ b/include/IntersectKernels.hpp
@@ -3,9 +3,6 @@
 
 #include "UtilKernels.hpp"
 
-typedef void (*intersectStart_t)(Vec3<float>&, Vec3<float>&, const float*,
-                                 float*, Vec3<float>*);
-
 /* This function calculates the intersection time and point between
  * a neutron (represented by x, y, z, va, vb, and vc) and a
  * rectangle (represented by A, B, and zdiff). The remaining
@@ -106,14 +103,9 @@ __device__ void intersectSphere(Vec3<float> &origins, Vec3<float> &vel,
                                 const float *shapeData,
                                 float *ts, Vec3<float> *pts);
 
-__device__ intersectStart_t boxInt = intersectBox;
-__device__ intersectStart_t cylInt = intersectCylinder;
-__device__ intersectStart_t pyrInt = intersectPyramid;
-__device__ intersectStart_t sphInt = intersectSphere;
-
-__global__ void intersect(intersectStart_t intPtr, Vec3<float> *origins, 
+__global__ void intersect(const int shapeKey, Vec3<float> *origins, 
                           Vec3<float> *vel, const float *shapeData, 
-                          const int N, const int groupSize,
+                          const int N,
                           float *ts, Vec3<float> *pts);
 
 #endif

--- a/include/IntersectKernels.hpp
+++ b/include/IntersectKernels.hpp
@@ -50,7 +50,7 @@ __device__ void intersectCylinderTopBottom(float *ts, Vec3<float> *pts,
  * in the correct spot in the ts and pts arrays.
  * This function can be called on device only.
  */
-__device__ void intersectTriangle(float &ts, Vec3<float> &pts,
+__device__ void intersectTriangle(float &ts, Vec3<float> *pts,
                                   const Vec3<float> &orig,
                                   const Vec3<float> &vel,
                                   const Vec3<float> &a,

--- a/include/Pyramid.hpp
+++ b/include/Pyramid.hpp
@@ -10,19 +10,25 @@
 struct Pyramid : public AbstractShape
 {
     // Default Constructor
-    Pyramid() { type = "Pyramid"; }
-
-    /* "Explicit" Constructor
-     * This function takes three doubles and sets the base dimensions
-     * and height with them.
-     */
-    Pyramid(double X, double Y, double h)
-    {
-        edgeX = X; edgeY = Y; height = h;
-        type = "Pyramid";
+    Pyramid() 
+    { 
+        type = "Pyramid"; 
+        data = new float[3];
+        data[0] = 0; data[1] = 0; data[2] = 0;
     }
 
-    ~Pyramid() { ; }
+    /* "Explicit" Constructor
+     * This function takes three floats and sets the base dimensions
+     * and height with them.
+     */
+    Pyramid(float X, float Y, float h)
+    {
+        type = "Pyramid";
+        data = new float[3];
+        data[0] = X; data[1] = Y; data[2] = h;
+    }
+
+    ~Pyramid() { delete [] data; }
 
     /* The function that handles the calculation of the intersection points
      * and times between the Pyramid object and the neutrons represented
@@ -41,11 +47,6 @@ struct Pyramid : public AbstractShape
                                    const int N, const int blockSize, const int numBlocks,
                                    std::vector<float> &int_times, 
                                    std::vector< Vec3<float> > &int_coords) override;
-
-    /* These members store the Pyramid's base dimensions (in X and Y
-     * components) and height.
-     */
-    double edgeX, edgeY, height;
 };
 
 #endif

--- a/include/ScatteringKernels.hpp
+++ b/include/ScatteringKernels.hpp
@@ -33,9 +33,15 @@ __global__ void calcScatteringSites(float *ts,
  * scattering velocity vector and stores the new velocity in the
  * neutron state velocity array.
  */
-__global__ void elasticScatteringKernel(const float *ray_time,
-                                        Vec3<float> *vel,
-                                        float *rands,
-                                        const int N);
+__device__ void isotropicScatteringKernel(//const float *ray_time,
+                                          //Vec3<float> *vel,
+                                          Vec3<float> &vel,
+                                          float *rands);
+                                          //const int N);
+
+__global__ void scatter(const int scatterKey, const float *ray_time, 
+                        Vec3<float> *vel, float *rands, const int N);
+
+
 
 #endif

--- a/include/Sphere.hpp
+++ b/include/Sphere.hpp
@@ -10,15 +10,25 @@
 struct Sphere : public AbstractShape
 {
     // Default Constructor
-    Sphere() { type = "Sphere"; }
+    Sphere() 
+    { 
+        type = "Sphere"; 
+        data = new float[1];
+        data[0] = 0;
+    }
 
     /* "Explicit" Constructor
-     * This function takes a double which is used to set the Sphere's
+     * This function takes a float which is used to set the Sphere's
      * radius.
      */
-    Sphere(const double r) { radius = r; type = "Sphere"; }
+    Sphere(const float r) 
+    { 
+        type = "Sphere"; 
+        data = new float[1];
+        data[0] = r;
+    }
 
-    ~Sphere() { ; }
+    ~Sphere() { delete [] data; }
 
     /* The function that handles the calculation of the intersection
      * points and times between the Sphere object and the neutrons
@@ -39,9 +49,6 @@ struct Sphere : public AbstractShape
                                    const int N, const int blockSize, const int numBlocks,
                                    std::vector<float> &int_times, 
                                    std::vector< Vec3<float> > &int_coords) override;
-
-    // This member stores the Sphere's radius.
-    double radius;
 };
 
 #endif

--- a/src/AbstractShape.cpp
+++ b/src/AbstractShape.cpp
@@ -1,0 +1,15 @@
+#include "AbstractShape.hpp"
+
+std::unordered_map<std::string, int> interKeyDict;
+
+AbstractShape::AbstractShape()
+{
+    type = "Shape";
+    if (interKeyDict.empty())
+    {
+        interKeyDict.insert(std::make_pair<std::string, int>("Box", 0));
+        interKeyDict.insert(std::make_pair<std::string, int>("Cylinder", 1));
+        interKeyDict.insert(std::make_pair<std::string, int>("Pyramid", 2));
+        interKeyDict.insert(std::make_pair<std::string, int>("Sphere", 3));
+    }
+}


### PR DESCRIPTION
Closes #8. Closes #9. Closes #10.

Refactors the CUDA code so that intersection and scattering processes go through the new general-use `intersect` and `scatter` CUDA kernels. The `__global__` functions that used to be used to perform these operations have been changed to `__device__` functions.

In both cases, the general kernels handle all the array-based data handling. The `__device__` functions (both new and old) only receive the small subset of the data that they're given by the `intersect` and `scatter` kernels.